### PR TITLE
docs: update all documentation for public readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,52 @@
 # Contributing to BlackBox Testing
 
-Thank you for your interest in contributing to the BlackBox Crash Bundle Standard.
+Thank you for contributing to the BlackBox Crash Bundle Standard.
 
 ## Developer Certificate of Origin (DCO)
 
-All contributions to this project must be accompanied by a Developer Certificate of Origin (DCO). This is a declaration that you have the right to submit the code you are contributing.
+All contributions must be accompanied by a Developer Certificate of Origin (DCO).
+Include the following line in each commit message:
 
-To sign off on your specific contribution, include the following line in your commit message:
+```text
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
 
-    Signed-off-by: Random J Developer <random@developer.example.org>
+Git can add this automatically:
 
-Git has a `-s` flag to `git commit` that automates this:
+```bash
+git commit -s -m "feat: my new feature"
+```
 
-    git commit -s -m "feat: my new feature"
+## Pull request process
 
-## Pull Request Process
+1. Strict compliance: adapter and tooling changes must pass `make compliance`.
+2. Spec-first: contract changes must be defined in `spec/` before implementation.
+3. Schema-first for contract edits: if behavior changes the manifest/layout, update `spec/manifest.schema.json` and docs first.
 
-1.  **Strict Compliance**: Any changes to adapters MUST pass the compliance suite (`make compliance`).
-2.  **Spec-First**: Changes to the bundle layout or manifest contract must be defined in `spec/` before implementation.
-3.  **One Bundle**: Identify if your change impacts the schema. If so, update `manifest.schema.json` first.
+## Development environment
 
-## Development Environment
+Use the Makefile entry points:
 
-Use the provided Makefile to orchestrate the repo:
+- `make install`: install dependencies for all adapters and tools.
+- `make lint`: run lint gates (`ruff`, `black --check`, `eslint`, `shellcheck`).
+- `make test-units`: run validator and adapter unit tests.
+- `make compliance`: run the full compliance suite (includes unit tests).
+- `make test`: run failing demo tests to generate sample bundles.
+- `make clean`: remove generated artifacts and bundles.
 
--   `make install`: Install dependencies
--   `make lint`: Run lint gates (ruff/black, eslint, shellcheck)
--   `make compliance`: Run the compliance suite against all adapters
+## Submitting a pull request
 
-## Code Style
+1. Fork the repository and create a branch from `main`.
+2. Keep branches focused on a single change (spec-only, adapter-only, or tooling-only whenever possible).
+3. Run local quality gates from the repository root:
+   - `make lint`
+   - `make test-units`
+   - `make compliance`
+4. Ensure commit messages are DCO-signed (`git commit -s ...`).
+5. Open a PR against `main`; include a concise summary and validation output.
 
--   **Python**: Follow PEP8 / Black.
--   **TypeScript**: Follow standard linting rules provided.
--   **Java**: Standard Maven conventions.
+## Code style
+
+- Python: follow PEP8/Black/Ruff.
+- TypeScript: follow ESLint rules in the adapter config.
+- Java: follow standard Maven/JUnit conventions.

--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ make compliance
 
 `make compliance` runs unit tests -> golden bundle validation -> adapter compliance checks.
 
-6. Run a failing demo per adapter (expected to fail and emit bundles):
+6. From the repository root, run a failing demo per adapter (expected to fail and emit bundles):
 
 ```bash
 # Java
-cd adapters/java-junit5 && mvn -q -Dtest=SampleFailingTest test
+(cd adapters/java-junit5 && mvn -q -Dtest=SampleFailingTest test)
 
 # Python
-cd adapters/python-pytest && python3 -m pytest -q tests/test_failing.py
+(cd adapters/python-pytest && python3 -m pytest -q tests/test_failing.py)
 
 # Node
-cd adapters/node-playwright && npm test
+(cd adapters/node-playwright && npm test)
 ```
 
 ## Make targets

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ project-blackbox-testing/
 - Python 3.8+
 - Node.js 18+
 - npm 9+
-- shellcheck 0.8+ (required for `make lint`)
+- shellcheck 0.8+ (required for `make lint`; install separately, e.g. `brew install shellcheck` or `apt-get install shellcheck`)
 
 ## Quickstart
 
@@ -121,7 +121,8 @@ Adapter details:
 
 - Compliance tooling is pinned in `tools/requirements.txt`.
 - Adapters use compatible semver ranges.
-- Reproducibility is enforced with lockfiles where available (currently `package-lock.json` for Node) plus CI validation.
+- Only Node currently commits a lockfile (`package-lock.json`).
+- Python and Java do not currently commit lockfiles; reproducibility there is CI-validated rather than lockfile-enforced.
 
 ## Non-goals
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,137 @@
 # BlackBox Testing
 
-BlackBox is a spec-first Crash Bundle Standard for test failures. The problem it solves: "Missing Evidence" in CI -- failures happen, but the evidence is missing or scattered.
+BlackBox is a spec-first Crash Bundle Standard for test failures across Java, Python, and Node.
+It solves the "Missing Evidence" CI problem: tests fail, but logs/artifacts/context are incomplete or scattered.
 
-This repository is spec-first. The JSON Schema and filesystem layout define the product. Adapters are thin recorders that emit identical bundles across Java, Python, and Node.
+This repository is spec-first: the contract in `spec/` is the product, and adapters are thin recorders.
 
 ## Philosophy
 
 - Recorder, not pilot: no browser lifecycle, retries, or test selection.
-- Spec-first: the contract (schema + layout) is the product.
-- Cross-language identical output: same bundle layout and manifest across runtimes.
-- Compliance enforced: adapters must pass the compliance suite.
+- Spec-first: the schema + filesystem layout are authoritative.
+- Cross-language parity: adapters emit the same bundle shape.
+- Compliance enforced: adapters must pass the compliance suite in CI.
 
 ## Bundle layout (failure only)
 
+```text
 blackbox-reports/
   {testId}_{timestamp}/
     manifest.json
     context.log
-    artifacts/ (optional)
-    attachments/ (optional)
+    attachments/   (optional)
+    artifacts/     (optional)
+```
 
-See `spec/bundle-layout.md` and `spec/manifest.schema.json` for the full contract.
+See [bundle layout](spec/bundle-layout.md) and [manifest schema](spec/manifest.schema.json) for full contract details.
 
-## Quickstart demos
+## Repository structure
 
-### Java (JUnit 5, Maven)
-cd adapters/java-junit5
-mvn -q -Dtest=SampleFailingTest test
+```text
+project-blackbox-testing/
+  spec/                 # contract + compliance tooling
+  adapters/             # java-junit5, python-pytest, node-playwright
+  tools/scripts/        # compliance + lint orchestration
+  Makefile              # local developer entry points
+```
 
-### Python (pytest)
-cd adapters/python-pytest
-python -m pip install -e .
-python -m pytest -q tests/test_failing.py
+## Prerequisites
 
-### Node (Playwright Test)
-cd adapters/node-playwright
-npm install
-npm test
+- Java (JDK) 11+
+- Maven 3.8+
+- Python 3.8+
+- Node.js 18+
+- npm 9+
+- shellcheck 0.8+ (required for `make lint`)
 
-Each failing demo writes a bundle under `blackbox-reports/` in the adapter directory.
+## Quickstart
 
-## Compliance suite
-Make sure you have `mvn`, `python3`, and `npm` installed.
+1. Clone and enter the repository:
 
+```bash
+git clone https://github.com/ramuks22/project-blackbox-testing.git
+cd project-blackbox-testing
+```
+
+2. Install dependencies:
+
+```bash
 make install
+```
 
+3. Run lint gates:
+
+```bash
 make lint
+```
 
+4. Run unit tests:
+
+```bash
+make test-units
+```
+
+5. Run full compliance:
+
+```bash
 make compliance
+```
 
-## Dependency management policy
+`make compliance` runs unit tests -> golden bundle validation -> adapter compliance checks.
 
-- **Compliance tooling**: Pinned via `tools/requirements.txt` for consistency.
-- **Adapters**: Use compatible semver ranges to ensure portability across versions.
-- **Reproducibility**: Achieved via lockfiles (e.g., `package-lock.json`) and CI pipelines.
+6. Run a failing demo per adapter (expected to fail and emit bundles):
 
+```bash
+# Java
+cd adapters/java-junit5 && mvn -q -Dtest=SampleFailingTest test
 
+# Python
+cd adapters/python-pytest && python3 -m pytest -q tests/test_failing.py
+
+# Node
+cd adapters/node-playwright && npm test
+```
+
+## Make targets
+
+- `make install`: install dependencies for tools and adapters.
+- `make lint`: run `ruff`, `black --check`, `eslint`, and `shellcheck`.
+- `make test-units`: run all validator and adapter unit tests.
+- `make compliance`: run the full compliance pipeline.
+- `make test`: run failing demos (intended failure path).
+- `make clean`: remove generated artifacts and bundles.
+
+## Adapter API quick reference
+
+All adapters expose the same recorder primitives:
+
+- `log(key, value)`: typed key/value context.
+- `step(message, level="INFO", data=None)`: structured step entries.
+- `attach(name, content)`: write text attachments into `attachments/`.
+
+Bundles are created only on failure.
+
+Adapter details:
+
+- [Java adapter](adapters/java-junit5/README.md)
+- [Python adapter](adapters/python-pytest/README.md)
+- [Node adapter](adapters/node-playwright/README.md)
+
+## Dependency policy
+
+- Compliance tooling is pinned in `tools/requirements.txt`.
+- Adapters use compatible semver ranges.
+- Reproducibility is enforced with lockfiles where available (currently `package-lock.json` for Node) plus CI validation.
 
 ## Non-goals
 
-- Not a test runner or selector
-- Not a dashboard or reporting UI
-- Not retries or flake management
-- Not browser or driver lifecycle management
+- Not a test runner or selector.
+- Not a dashboard or reporting UI.
+- Not retries or flake management.
+- Not browser or driver lifecycle management.
+
+## Project docs
+
+- [Contributing guide](CONTRIBUTING.md)
+- [Versioning policy](VERSIONING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/adapters/java-junit5/README.md
+++ b/adapters/java-junit5/README.md
@@ -1,18 +1,25 @@
 # BlackBox JUnit 5 Adapter
 
+## Prerequisites
+
+- Java (JDK) 11+
+- Maven 3.8+
+
 ## Install
 
-Maven dependency (placeholder):
+This adapter is developed in-repo. It is not published as a Maven artifact yet.
+Use it directly from this monorepo.
 
-<dependency>
-  <groupId>dev.blackbox</groupId>
-  <artifactId>blackbox-junit5</artifactId>
-  <version>0.1.0</version>
-  <scope>test</scope>
-</dependency>
+From the repo root:
+
+```bash
+cd adapters/java-junit5
+mvn -v
+```
 
 ## Usage
 
+```java
 @ExtendWith(BlackBoxExtension.class)
 class MyTest {
   @Test
@@ -23,18 +30,36 @@ class MyTest {
     Assertions.fail("boom");
   }
 }
+```
 
-Note: the static API relies on the test thread (MVP constraint).
+Note: the static API relies on the current test thread (MVP constraint).
+
+## Running tests
+
+Run unit tests (must pass):
+
+```bash
+cd adapters/java-junit5
+mvn test
+```
+
+Run the demo failing test (expected failure, emits bundle):
+
+```bash
+cd adapters/java-junit5
+mvn -q -Dtest=SampleFailingTest test
+```
 
 ## TestId derivation
 
-canonical = "{testClass}::{testName}"
+`canonical = "{testClass}::{testName}"`
 
-- testClass: fully-qualified class name
-- testName: method name if available, else display name
-- testId: sha1(canonical).hexdigest().slice(0, 16)
+- `testClass`: fully-qualified class name
+- `testName`: method name if available, else display name
+- `testId`: `sha1(canonical).hexdigest().slice(0, 16)`
 
 ## Output directory
 
 Default: `blackbox-reports/`
+
 Override: `-Dblackbox.outputDir=/path/to/output`

--- a/adapters/java-junit5/pom.xml
+++ b/adapters/java-junit5/pom.xml
@@ -9,8 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <junit.jupiter.version>5.10.1</junit.jupiter.version>
     <jackson.version>2.15.2</jackson.version>
   </properties>

--- a/adapters/java-junit5/pom.xml
+++ b/adapters/java-junit5/pom.xml
@@ -51,14 +51,7 @@
           </excludes>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
-        <configuration>
-          <release>11</release>
-        </configuration>
-      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/adapters/java-junit5/pom.xml
+++ b/adapters/java-junit5/pom.xml
@@ -51,6 +51,14 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/adapters/node-playwright/README.md
+++ b/adapters/node-playwright/README.md
@@ -1,12 +1,23 @@
 # BlackBox Playwright Test Adapter
 
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+
 ## Install
 
+```bash
+cd adapters/node-playwright
 npm install
+```
 
 ## Usage
 
-import { test, expect } from "./src/fixtures";
+Example test file in `tests/`:
+
+```ts
+import { test, expect } from "../src/fixtures";
 
 test("fails", async ({ blackbox }) => {
   blackbox.log("user", "alice");
@@ -14,16 +25,34 @@ test("fails", async ({ blackbox }) => {
   blackbox.attach("note.txt", "hello");
   expect(1).toBe(2);
 });
+```
+
+## Running tests
+
+Run unit tests (must pass):
+
+```bash
+cd adapters/node-playwright
+npm run test:unit
+```
+
+Run the demo failing test (expected failure, emits bundle):
+
+```bash
+cd adapters/node-playwright
+npm test
+```
 
 ## TestId derivation
 
-canonical = "{testClass}::{testName}"
+`canonical = "{testClass}::{testName}"`
 
-- testClass: spec file path (relative)
-- testName: testInfo.titlePath().join("::")
-- testId: sha1(canonical).hexdigest().slice(0, 16)
+- `testClass`: spec file path (relative)
+- `testName`: `testInfo.titlePath().join("::")`
+- `testId`: `sha1(canonical).hexdigest().slice(0, 16)`
 
 ## Output directory
 
 Default: `blackbox-reports/`
+
 Override: env var `BLACKBOX_OUTPUT_DIR`

--- a/adapters/node-playwright/package-lock.json
+++ b/adapters/node-playwright/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@playwright/test": "^1.41.2",
+        "@types/node": "^25.2.3",
         "eslint": "^9.19.0",
         "typescript": "^5.4.0",
         "typescript-eslint": "^8.22.0"
@@ -240,6 +241,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.55.0",
@@ -1455,6 +1466,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/adapters/node-playwright/package.json
+++ b/adapters/node-playwright/package.json
@@ -8,10 +8,11 @@
     "lint": "eslint src tests"
   },
   "devDependencies": {
-    "@playwright/test": "^1.41.2",
     "@eslint/js": "^9.19.0",
+    "@playwright/test": "^1.41.2",
+    "@types/node": "^25.2.3",
     "eslint": "^9.19.0",
-    "typescript-eslint": "^8.22.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "typescript-eslint": "^8.22.0"
   }
 }

--- a/adapters/node-playwright/src/blackbox.ts
+++ b/adapters/node-playwright/src/blackbox.ts
@@ -102,10 +102,12 @@ export class BlackBoxRecorder {
     this.testClass = filePath.replace(/\\/g, "/");
     let tp: string[] = [];
     try {
-      if (typeof testInfo.titlePath === "function") {
-        tp = testInfo.titlePath();
-      } else if (Array.isArray(testInfo.titlePath)) {
-        tp = testInfo.titlePath;
+      // Cast to any to avoid TS error: Type 'never' has no call signatures
+      const ti = testInfo as any;
+      if (typeof ti.titlePath === "function") {
+        tp = ti.titlePath();
+      } else if (Array.isArray(ti.titlePath)) {
+        tp = ti.titlePath;
       }
     } catch {
       // ignore
@@ -176,7 +178,7 @@ export class BlackBoxRecorder {
     }
 
     const durationMs = testInfo.duration ?? endTime.getTime() - this.startTime.getTime();
-    const error = (testInfo.errors && testInfo.errors[0]) || (testInfo as any).error;
+    const error = ((testInfo.errors && testInfo.errors[0]) || (testInfo as any).error) as any;
     const exceptionType = error && error.name ? error.name : "Error";
     const exceptionMessage = error && error.message ? error.message : "Test failed";
     const exceptionStack = error && error.stack ? error.stack : undefined;

--- a/adapters/node-playwright/tsconfig.json
+++ b/adapters/node-playwright/tsconfig.json
@@ -4,8 +4,10 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "strict": true,
+    "types": [
+      "node"
+    ],
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "skipLibCheck": true
   },
   "include": [

--- a/adapters/node-playwright/tsconfig.json
+++ b/adapters/node-playwright/tsconfig.json
@@ -6,7 +6,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["node", "@playwright/test"]
+    "skipLibCheck": true
   },
-  "include": ["src", "tests"]
+  "include": [
+    "src",
+    "tests"
+  ]
 }

--- a/adapters/python-pytest/README.md
+++ b/adapters/python-pytest/README.md
@@ -1,30 +1,58 @@
 # BlackBox Pytest Adapter
 
+## Prerequisites
+
+- Python 3.8+
+- pytest 7+
+
 ## Install
 
-pip install -e .
+```bash
+cd adapters/python-pytest
+python3 -m pip install -e .
+```
 
 ## Usage
 
+```python
 def test_fails(blackbox):
     blackbox.log("user", "alice")
     blackbox.step("start")
     blackbox.attach("note.txt", "hello")
     assert 1 == 2
+```
 
-Optional autouse (in pytest.ini or CLI):
-- pytest.ini: blackbox_autouse = true
-- CLI: --blackbox-autouse
+Optional autouse mode:
+
+- `pytest.ini`: `blackbox_autouse = true`
+- CLI: `--blackbox-autouse`
+
+## Running tests
+
+Run unit tests (must pass):
+
+```bash
+cd adapters/python-pytest
+python3 -m pytest -q tests/test_plugin_units.py
+```
+
+Run the demo failing test (expected failure, emits bundle):
+
+```bash
+cd adapters/python-pytest
+python3 -m pytest -q tests/test_failing.py
+```
 
 ## TestId derivation
 
-canonical = "{testClass}::{testName}"
+`canonical = "{testClass}::{testName}"`
 
-- testClass: nodeid file component (module path)
-- testName: function name without parameter ids
-- testId: sha1(canonical).hexdigest().slice(0, 16)
+- `testClass`: nodeid file component (module path)
+- `testName`: function name without parameter IDs
+- `testId`: `sha1(canonical).hexdigest().slice(0, 16)`
 
 ## Output directory
 
 Default: `blackbox-reports/`
+
 Override: env var `BLACKBOX_OUTPUT_DIR`

--- a/spec/compliance/README.md
+++ b/spec/compliance/README.md
@@ -1,9 +1,42 @@
 # Compliance Suite
 
-This folder contains schema validation and golden manifests.
+This folder contains validation tooling, golden bundles, and validator unit tests for the BlackBox contract.
 
-- `validate_manifest.py` validates a **Bundle Directory** (containing `manifest.json`, `context.log`, etc.) against the Schema and File Layout.
-- `golden/9f2a0c1b3d4e5a6b_20260202T143000Z/` is a known-good reference bundle that passes all strict checks.
+## Contents
 
-Usage:
-python spec/compliance/validate_manifest.py spec/compliance/golden/9f2a0c1b3d4e5a6b_20260202T143000Z/manifest.json
+- `validate_manifest.py`: validates a bundle directory against JSON schema and filesystem rules.
+- `golden/9f2a0c1b3d4e5a6b_20260202T143000Z/`: known-good bundle that must pass.
+- `golden/invalid_*/`: adversarial bundles that must fail:
+  - `invalid_missing_manifest/`
+  - `invalid_missing_context/`
+  - `invalid_extra_file/`
+  - `invalid_path_traversal/`
+  - `invalid_attachments_undeclared/`
+- `tests/`: validator unit tests.
+
+## Usage
+
+Validate a bundle:
+
+```bash
+python3 spec/compliance/validate_manifest.py path/to/bundle/manifest.json
+```
+
+Run validator unit tests:
+
+```bash
+cd spec/compliance
+python3 -m pytest tests/ -v
+```
+
+Run full repo compliance:
+
+```bash
+make compliance
+```
+
+Compliance execution order:
+
+1. Validator + adapter unit tests
+2. Golden valid bundle check
+3. Java/Python/Node failing-demo bundle checks


### PR DESCRIPTION
## Summary

Updates all documentation for public-reader clarity, addressing gaps identified in the QA doc review.

## Documentation Updates (6 files)

| File | Key Changes |
|---|---|
| **README.md** | Prerequisites table (incl. shellcheck), fenced code blocks, repo structure, API quick reference, Make targets, clone step, markdown links |
| **CONTRIBUTING.md** | Added `make test-units`, `make lint`, PR submission workflow |
| **spec/compliance/README.md** | Documented invalid golden bundles, validator tests, fenced commands |
| **adapters/java-junit5/README.md** | Prerequisites, fenced code, running tests section, removed 'placeholder' wording |
| **adapters/python-pytest/README.md** | Prerequisites, fenced code, running tests section |
| **adapters/node-playwright/README.md** | Fixed import path (`./src/fixtures` → `../src/fixtures`), prerequisites, fenced code, running tests |

## Detailed Improvements

### 1. Developer Experience
- **Copy-paste safety**: Demo commands now use subshells `(cd ... && ...)` to prevent directory state coupling
- **Explicit CWD**: "From the repository root" guidance added
- **Prerequisites**: Added explicit install instructions for `shellcheck` (required for lint)

### 2. Technical Accuracy
- **Reproducibility**: Clarified that only Node uses a committed lockfile; Java/Python rely on CI validation
- **Workflows**: Documented the full development lifecycle (fork -> test -> PR)

## Exceptions (Non-Documentation Changes)

### Node.js (TypeScript) Fixes
- **Dependencies**: Added `@types/node` to `adapters/node-playwright/package.json` (fixes local "Cannot find type..." errors).
- **Code Logic**: Fixed strict type errors in `src/blackbox.ts` (checked compatibility for `testInfo.titlePath` / `error.name`).
- **Configuration**: Updated `tsconfig.json` to allow standard type discovery (removed strict `types` list) while keeping `"types": ["node"]` for global process/fs types.

### Java (JUnit 5) Fixes
- **Build Configuration**: Updated `pom.xml` to use `<maven.compiler.release>11</maven.compiler.release>`.
  - Replaces legacy `source`/`target` properties for better cross-compilation support on modern JDKs (17/21).
  - Keeps `pom.xml` clean (no extra plugin configuration), relying on standard Maven behavior.

All non-doc changes were approved to ensure a clean build experience for developers.

## Quality Gates

| Check | Result |
|---|---|
| CI `compliance` workflow | ✅ PASSED |

No runtime behavior changes.
